### PR TITLE
fix base 8 shell issue

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -17,5 +17,5 @@ if [[ -z "${AOC_SESSION-""}" ]]; then
   exit 1
 fi
 
-URL="https://adventofcode.com/2021/day/$(("$1" + 0))/input"
+URL="https://adventofcode.com/2021/day/$(("10#$1" + 0))/input"
 curl -f "$URL" --cookie "session=$AOC_SESSION" -s | tee "./inputs/$1.in"


### PR DESCRIPTION
I ran across your code after you pointed to it on reddit. Your fetch.sh is great, but it fails on days 08 and 09 because of octal issues:

`./fetch.sh: line 20: 08: value too great for base (error token is "08")`

I fixed it to force base 10 interpretation as suggested here: https://stackoverflow.com/a/12821845

Thanks for sharing your work!